### PR TITLE
feat: Implement TTS model and dual voice selection

### DIFF
--- a/audio_synthesizer.py
+++ b/audio_synthesizer.py
@@ -30,7 +30,6 @@ class AudioSynthesizer:
             raise ValueError("Gemini API key is required. Set GEMINI_API_KEY environment variable or pass as parameter.")
         
         self.client = genai.Client(api_key=self.api_key)
-        self.model = "gemini-2.5-pro-preview-tts"  # Using the TTS-enabled model
         
         # Default voice configurations
         self.default_voice = "Enceladus"  # Warm, comforting voice suitable for "daddy" ASMR
@@ -41,13 +40,14 @@ class AudioSynthesizer:
             "Io"          # Soft, nurturing voice
         ]
     
-    def synthesize_audio(self, script, output_file, speaker1_name="Speaker1", speaker1_voice="Enceladus", speaker2_name="Speaker2", speaker2_voice="Puck"):
+    def synthesize_audio(self, script, output_file, model_name, speaker1_name="Speaker1", speaker1_voice="Enceladus", speaker2_name="Speaker2", speaker2_voice="Puck"):
         """
         Synthesize audio from the provided script for two speakers.
         
         Args:
             script (str): The script text with speaker annotations (e.g., "Speaker1:", "Speaker2:")
             output_file (str): Path to save the output audio file
+            model_name (str): Name of the TTS model to use, like 'gemini-2.5-pro-preview-tts' or 'gemini-2.5-flash-preview-tts'.
             speaker1_name (str): Name/identifier for Speaker 1 in the script
             speaker1_voice (str): Voice to use for Speaker 1
             speaker2_name (str): Name/identifier for Speaker 2 in the script
@@ -108,7 +108,7 @@ class AudioSynthesizer:
             # Generate the audio content
             audio_data = None
             for chunk in self.client.models.generate_content_stream(
-                model=self.model,
+                model=model_name,
                 contents=contents,
                 config=generate_content_config,
             ):
@@ -259,6 +259,7 @@ if __name__ == "__main__":
     output_path = synthesizer.synthesize_audio(
         test_script, 
         "test_multi_speaker_output.wav",
+        model_name="gemini-2.5-flash-preview-tts",
         speaker1_name="Alex",
         speaker1_voice="Enceladus", # Or any from available_voices
         speaker2_name="Jordan",

--- a/auto_daddy.py
+++ b/auto_daddy.py
@@ -78,12 +78,13 @@ class AutoDaddy:
         self.current_script = script_text
         return self.current_script
     
-    def generate_audio(self, script=None, speaker1_name="Speaker1", speaker1_voice="Enceladus", speaker2_name="Speaker2", speaker2_voice="Puck", output_filename=None):
+    def generate_audio(self, script=None, tts_model_name="gemini-2.5-pro-preview-tts", speaker1_name="Speaker1", speaker1_voice="Enceladus", speaker2_name="Speaker2", speaker2_voice="Puck", output_filename=None):
         """
         Generate audio from the current or provided script for two speakers.
         
         Args:
             script (str, optional): Script to use. If None, uses current_script.
+            tts_model_name (str): Name of the TTS model to use (e.g., "gemini-2.5-pro-preview-tts", "gemini-2.5-flash-preview-tts").
             speaker1_name (str): Name/identifier for Speaker 1 in the script.
             speaker1_voice (str): Voice to use for Speaker 1.
             speaker2_name (str): Name/identifier for Speaker 2 in the script.
@@ -110,6 +111,7 @@ class AutoDaddy:
         self.current_audio_path = self.audio_synthesizer.synthesize_audio(
             script=script_to_use,
             output_file=output_path,
+            model_name=tts_model_name,
             speaker1_name=speaker1_name,
             speaker1_voice=speaker1_voice,
             speaker2_name=speaker2_name,
@@ -193,6 +195,7 @@ if __name__ == "__main__":
     if not script.startswith("Error"): # Proceed only if script generation was successful
         print(f"Generating two-speaker audio with voices {s1_voice} for {s1_name} and {s2_voice} for {s2_name}...")
         audio_path = auto_daddy.generate_audio(
+                tts_model_name="gemini-2.5-flash-preview-tts",
             speaker1_name=s1_name,
             speaker1_voice=s1_voice,
             speaker2_name=s2_name,


### PR DESCRIPTION
This commit introduces two major enhancements:
1.  **TTS Model Selection:** You can now choose between `gemini-2.5-pro-preview-tts` and `gemini-2.5-flash-preview-tts` models for audio generation via a new dropdown in the UI.
2.  **Dual Voice Selection:** The UI now provides two separate voice selection dropdowns, one for "Speaker 1" and one for "Speaker 2", allowing for distinct voices in the generated audio.

Changes include:
-   **`audio_synthesizer.py`**: `AudioSynthesizer.synthesize_audio`
    now accepts a `model_name` parameter, and `__init__` no longer
    hardcodes the model.
-   **`auto_daddy.py`**: `AutoDaddy.generate_audio` now accepts a
    `tts_model_name` parameter and passes it to the synthesizer.
-   **`ui.py`**:
    -   `AutoDaddyUI` updated with new QComboBoxes for TTS model
        and two speaker voices.
    -   `GenerateAudioThread` modified to accept and pass
        `tts_model_name`, `speaker1_voice`, and `speaker2_voice`
        to the backend.
    -   `AutoDaddyUI.generate_audio` updated to gather these
        new selections from the UI.
-   Docstrings and comments updated across modified files to
    reflect these new parameters and functionalities.